### PR TITLE
Add a check that if port 22 is not used then do not remove it!

### DIFF
--- a/secure.sh
+++ b/secure.sh
@@ -19,6 +19,7 @@ sudo ufw enable
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 sudo ufw app list
+sudo ufw allow ssh
 sudo ufw allow $SSH_PORT/tcp
 sudo ufw allow 80/tcp
 sudo ufw allow 443/tcp

--- a/secure.sh
+++ b/secure.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-
 #OVH's Securing guide section
-sudo apt update && sudo apt upgrade
+sudo apt update && sudo apt upgrade -y
 read -p "Enter the custom SSH port you want to allow in UFW (or press Enter to use the default "22"): " SSH_PORT
 SSH_PORT=${SSH_PORT:-22}
 sudo vim /etc/ssh/sshd_config
@@ -9,20 +8,21 @@ sudo systemctl restart sshd
 sudo vim /lib/systemd/system/ssh.socket
 sudo systemctl daemon-reload
 sudo systemctl restart ssh.service
-sudo apt install fail2ban
+sudo apt install fail2ban -y
 sudo cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
 sudo vim /etc/fail2ban/jail.local
 sudo systemctl restart fail2ban
 #Tecmint's Securing guide section
-sudo apt install ufw
+sudo apt install ufw -y 
 sudo ufw status verbose
 sudo ufw enable
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 sudo ufw app list
-sudo ufw allow ssh
 sudo ufw allow $SSH_PORT/tcp
 sudo ufw allow 80/tcp
 sudo ufw allow 443/tcp
-sudo ufw delete allow 22/tcp
+if [[ $SSH_PORT != "22" ]]; then
+	sudo ufw delete allow 22/tcp
+fi
 sudo ufw status


### PR DESCRIPTION
Hello there, so there was a bug that if someone used port 22 it will be removed even though they are using port 22 which will cause theme to be locked out of their server, so i add an if statement that it only removes port 22 if it is not used, ~i also removed UFW allow ssh, since apparently this just allows port 22 which is not needed.~, i add ufw allow ssh back is it turns out it is needed